### PR TITLE
Add setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In this exercise you will work with your group to get to full code coverage and 
 1. Clone a copy of this exercise. This command makes a new folder called `code-coverage-exercise`, and then puts the exercise into this new folder. You do not need to fork the repository.
 
 ```bash
-$ git clone ...
+git clone ...
 ```
 
 Use `ls` to confirm there's a new project folder
@@ -14,19 +14,19 @@ Use `ls` to confirm there's a new project folder
 2. Move your location into this project folder
 
 ```bash
-$ cd code-coverage-exercise
+cd code-coverage-exercise
 ```
 
 3. Create a virtual environment named `venv` for this project:
 
 ```bash
-$ python3 -m venv venv
+python3 -m venv venv
 ```
 
 4. Activate this environment:
 
 ```bash
-$ source venv/bin/activate
+source venv/bin/activate
 ```
 
 Verify that you're in a python3 virtual environment by running:
@@ -38,13 +38,13 @@ Verify that you're in a python3 virtual environment by running:
 
 ```bash
 # Must be in activated virtual environment
-$ pip install -r requirements.txt
+pip install -r requirements.txt
 ```
 
 6. Exit and re-enter the virtual enviornment with the following command. This is needed to ensure the correct version of pytest is used in the terminal.
 
 ```bash
-$ deactivate && source venv/bin/activate
+deactivate && source venv/bin/activate
 ```
 
 ## Checking Code Coverage

--- a/README.md
+++ b/README.md
@@ -2,7 +2,52 @@
 
 In this exercise you will work with your group to get to full code coverage and fix any bugs that you find.
 
-You will need to clone this project and do your normal Python environment setup (`venv`, instaling packages, etc).
+## Setup
+1. Clone a copy of this exercise. This command makes a new folder called `code-coverage-exercise`, and then puts the exercise into this new folder. You do not need to fork the repository.
+
+```bash
+$ git clone ...
+```
+
+Use `ls` to confirm there's a new project folder
+
+2. Move your location into this project folder
+
+```bash
+$ cd code-coverage-exercise
+```
+
+3. Create a virtual environment named `venv` for this project:
+
+```bash
+$ python3 -m venv venv
+```
+
+4. Activate this environment:
+
+```bash
+$ source venv/bin/activate
+```
+
+Verify that you're in a python3 virtual environment by running:
+
+- `$ python --version` should output a Python 3 version
+- `$ pip --version` should output that it is working with Python 3
+
+5. Install dependencies once at the beginning of this exercise with
+
+```bash
+# Must be in activated virtual environment
+$ pip install -r requirements.txt
+```
+
+6. Exit and re-enter the virtual enviornment with the following command. This is needed to ensure the correct version of pytest is used in the terminal.
+
+```bash
+$ deactivate && source venv/bin/activate
+```
+
+## Checking Code Coverage
 
 To check the code coverage you can run:
 ```


### PR DESCRIPTION
- Adds instructions for cloning and setting up venv.

- Largely copied from adagrams readme, but with an extra step added
to ensure the correct pytest version is picked up.